### PR TITLE
Add skeleton for La Brute Reskin Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/labrute-reskin-studio/README.md
+++ b/labrute-reskin-studio/README.md
@@ -1,0 +1,28 @@
+# La Brute Reskin Studio
+
+This directory contains a minimal setup for a local React + PixiJS application that visualises **La Brute** characters and allows you to swap body parts, weapons and other assets.
+
+The project is intentionally lightweight so you can extend it with your own build tooling and assets. It is meant to run entirely offline.
+
+## Setup
+
+1. Install [Node.js](https://nodejs.org/) (version 18 or newer).
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+4. The application will open at `http://localhost:5173`.
+
+## Adding assets
+
+1. Export assets from the `LaBrute.fla` file using `labrute-fla-parser`:
+   ```bash
+   npx labrute-fla-parser --input LaBrute.fla --output ./export
+   ```
+2. Import the generated `SymbolXXX.ts` modules in `src/avatar/AvatarBrute.tsx` and compose your brute.
+
+Refer to the main project documentation for a detailed workflow.

--- a/labrute-reskin-studio/export/Symbol475.ts
+++ b/labrute-reskin-studio/export/Symbol475.ts
@@ -1,0 +1,3 @@
+export const Symbol475 = {
+  paths: 'path/to/body.png'
+};

--- a/labrute-reskin-studio/export/symbolMap.json
+++ b/labrute-reskin-studio/export/symbolMap.json
@@ -1,0 +1,3 @@
+{
+  "Symbol475": "Symbol475.ts"
+}

--- a/labrute-reskin-studio/index.html
+++ b/labrute-reskin-studio/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>La Brute Reskin Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/labrute-reskin-studio/package.json
+++ b/labrute-reskin-studio/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "labrute-reskin-studio",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "pixi.js": "^8.0.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/labrute-reskin-studio/src/App.tsx
+++ b/labrute-reskin-studio/src/App.tsx
@@ -1,0 +1,10 @@
+import AvatarBrute from './avatar/AvatarBrute';
+
+export default function App() {
+  return (
+    <div>
+      <h1>La Brute Reskin Studio</h1>
+      <AvatarBrute />
+    </div>
+  );
+}

--- a/labrute-reskin-studio/src/avatar/AvatarBrute.tsx
+++ b/labrute-reskin-studio/src/avatar/AvatarBrute.tsx
@@ -1,0 +1,36 @@
+import * as PIXI from 'pixi.js';
+import { useEffect, useRef } from 'react';
+import { Symbol475 } from '../../export/Symbol475';
+
+export interface AvatarBruteProps {
+  skin?: number;
+  weapon?: { paths: string };
+}
+
+export default function AvatarBrute({ skin = 0xffc8b0, weapon }: AvatarBruteProps) {
+  const container = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const app = new PIXI.Application({ width: 300, height: 400, backgroundAlpha: 0 });
+    if (container.current) {
+      container.current.innerHTML = '';
+      container.current.appendChild(app.view as unknown as Node);
+    }
+
+    const brute = new PIXI.Container();
+    const body = PIXI.Sprite.from(Symbol475.paths);
+    body.tint = skin;
+    brute.addChild(body);
+
+    if (weapon) {
+      const weaponSprite = PIXI.Sprite.from(weapon.paths);
+      brute.addChild(weaponSprite);
+    }
+
+    brute.position.set(150, 200);
+    app.stage.addChild(brute);
+    return () => app.destroy(true, { children: true });
+  }, [skin, weapon]);
+
+  return <div ref={container} />;
+}

--- a/labrute-reskin-studio/src/main.tsx
+++ b/labrute-reskin-studio/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/labrute-reskin-studio/tsconfig.json
+++ b/labrute-reskin-studio/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/labrute-reskin-studio/vite.config.ts
+++ b/labrute-reskin-studio/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add a `.gitignore`
- create `labrute-reskin-studio` directory with a minimal React+PixiJS setup
- document how to run the studio

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not installed)*