### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,13 +214,13 @@ The game also has a lot of forks that add their own features, difficulty scaling
 
 - **CroftEngine** - An open-source Tomb Raider 1 engine remake. [[source]](https://github.com/stohrendorf/CroftEngine)
 
-- **[Lugaru: The Rabbit's Foot](http://www.wolfire.com/lugaru)** - Cross-platform, open-source 3D action game. [[soruce]](https://github.com/WolfireGames/lugaru)
+- **[Lugaru: The Rabbit's Foot](http://www.wolfire.com/lugaru)** - Cross-platform, open-source 3D action game. [[source]](https://github.com/WolfireGames/lugaru)
 
 - **[OpenLara](http://xproger.info/projects/OpenLara)** - Classic Tomb Raider open-source engine [[source]](https://github.com/XProger/OpenLara)
 
 - **[OpenRW](https://openrw.org)** - A Grand Theft Auto III re-implementation. [[source]](https://github.com/rwengine/openrw)
 
-- **[Overgrowth](https://overgrowth.wolfire.com/)** - The sequel to Lugaru. [[soruce]](https://github.com/WolfireGames/overgrowth)
+- **[Overgrowth](https://overgrowth.wolfire.com/)** - The sequel to Lugaru. [[source]](https://github.com/WolfireGames/overgrowth)
 
 - **RE3** - The fully reversed source code for GTA III and GTA VC. [[source]](https://github.com/halpz/re3)
 


### PR DESCRIPTION
## Summary
- fix misspelled `soruce` links in Third-Person games section

## Testing
- `curl -L https://chatgpt.com/share/68458690-a988-8000-9408-66432f692464` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_684586c5779083209e6ed4aab4435b4c